### PR TITLE
#30 카테고리 계층구조로 전체 조회하기

### DIFF
--- a/src/main/java/com/example/reactivewebexample/category/dto/Categories.java
+++ b/src/main/java/com/example/reactivewebexample/category/dto/Categories.java
@@ -1,0 +1,69 @@
+package com.example.reactivewebexample.category.dto;
+
+import static org.springframework.hateoas.server.reactive.WebFluxLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.reactive.WebFluxLinkBuilder.methodOn;
+
+import com.example.reactivewebexample.category.controller.CategoryController;
+import com.example.reactivewebexample.category.document.Category;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.Getter;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Getter
+public class Categories {
+    private final Category category;
+    private List<Categories> children;
+
+    public Categories(Category category) {
+        this.category = category;
+    }
+
+    public void addChildCategory(Category category) {
+        if(Objects.isNull(this.children)) {
+            this.children = new ArrayList<>();
+        }
+
+        this.children.add(new Categories(category));
+    }
+
+    public Mono<EntityModel<Category>> parseCategoryHal(Categories categories) {
+        CategoryController controller = methodOn(CategoryController.class);
+        String categoryId = categories.category.getId().toHexString();
+
+        Mono<Link> updateLink = linkTo(controller.updateCategory(categoryId,null))
+            .withRel("update")
+            .toMono();
+        Mono<Link> deleteLink = linkTo(controller.deleteCategory(categoryId))
+            .withRel("delete")
+            .toMono();
+        Mono<Category> categoryMono = Mono.just(categories.category);
+
+        return Mono.zip(updateLink, deleteLink, categoryMono)
+            .flatMap(tuple -> Mono.just(EntityModel.of(tuple.getT3(), tuple.getT1(), tuple.getT2())));
+    }
+
+    public Mono<List<HalCategories>> parseChildrenHal(Categories categories) {
+        return Flux.fromIterable(categories.children)
+            .flatMap(categories1 -> {
+                Mono<EntityModel<Category>> categoryEntityModel =
+                    parseCategoryHal(categories1);
+
+                if(Objects.nonNull(categories1.getChildren())) {
+                    Mono<List<HalCategories>> halCategoriesFlux = parseChildrenHal(categories1);
+                    return halCategoriesFlux.zipWith(categoryEntityModel)
+                        .flatMap(tuple ->
+                            Mono.just(new HalCategories(tuple.getT2(), tuple.getT1())));
+                }
+
+                return categoryEntityModel
+                    .flatMap(entityModel ->
+                        Mono.just(new HalCategories(entityModel, null))).flux();
+            })
+            .collectList();
+    }
+}

--- a/src/main/java/com/example/reactivewebexample/category/dto/CategoryComposite.java
+++ b/src/main/java/com/example/reactivewebexample/category/dto/CategoryComposite.java
@@ -1,0 +1,64 @@
+package com.example.reactivewebexample.category.dto;
+
+import static org.springframework.hateoas.server.reactive.WebFluxLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.reactive.WebFluxLinkBuilder.methodOn;
+
+import com.example.reactivewebexample.category.controller.CategoryController;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.ToString;
+import org.bson.types.ObjectId;
+import org.springframework.hateoas.CollectionModel;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Getter
+@ToString
+public class CategoryComposite {
+    private final List<Categories> categoryComposite = new ArrayList<>();
+
+    public void addCategoryComposite(Categories categories) { // 부모 카테고리 추가
+        this.categoryComposite.add(categories);
+    }
+
+    public Mono<CollectionModel<HalCategories>> toHal() {
+        CategoryController controller = methodOn(CategoryController.class);
+        return Flux.fromIterable(this.categoryComposite)
+            .flatMap(categories ->
+                Mono.zip(categories.parseCategoryHal(categories),
+                    categories.parseChildrenHal(categories))
+                .flatMap(tuple -> Mono.just(new HalCategories(tuple.getT1(), tuple.getT2()))))
+            .collectList()
+            .zipWith(linkTo(controller.retrieveAllCategories()).withSelfRel().toMono())
+            .flatMap(o -> Mono.just(CollectionModel.of(o.getT1(), o.getT2())));
+    }
+
+    public Optional<Categories> findParentCategory(ObjectId parentId) {
+        return categoryComposite.stream()
+            .map(categories -> findParentCategory(parentId, categories))
+            .findAny()
+            .orElseThrow(RuntimeException::new);
+    }
+
+    private Optional<Categories> findParentCategory(ObjectId parentId, Categories categories) {
+        ObjectId parentObjectId = categories.getCategory().getId();
+        if(parentObjectId.equals(parentId)) {
+            return Optional.of(categories);
+        }
+
+        if(Objects.nonNull(categories.getChildren())) {
+            return categories.getChildren().stream()
+                .map(categories1 -> findParentCategory(parentId, categories1))
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElse(Optional.empty());
+        }
+
+        return Optional.empty();
+    }
+
+
+}

--- a/src/main/java/com/example/reactivewebexample/category/dto/HalCategories.java
+++ b/src/main/java/com/example/reactivewebexample/category/dto/HalCategories.java
@@ -1,0 +1,17 @@
+package com.example.reactivewebexample.category.dto;
+
+import com.example.reactivewebexample.category.document.Category;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.hateoas.EntityModel;
+
+@Getter
+public class HalCategories {
+    private final EntityModel<Category> category;
+    private final List<HalCategories> children;
+
+    public HalCategories(EntityModel<Category> category, List<HalCategories> children) {
+        this.category = category;
+        this.children = children;
+    }
+}

--- a/src/main/java/com/example/reactivewebexample/category/service/CategoryService.java
+++ b/src/main/java/com/example/reactivewebexample/category/service/CategoryService.java
@@ -1,10 +1,9 @@
 package com.example.reactivewebexample.category.service;
 
-import com.example.reactivewebexample.category.document.Category;
+import com.example.reactivewebexample.category.dto.CategoryComposite;
 import com.example.reactivewebexample.category.dto.CategorySaveDto;
 import com.example.reactivewebexample.common.dto.CreationDto;
 import com.example.reactivewebexample.common.dto.ModifyDto;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface CategoryService {
@@ -14,5 +13,5 @@ public interface CategoryService {
 
     Mono<Void> deleteCategory(String categoryId);
 
-    Flux<Category> retrieveCategories();
+    Mono<CategoryComposite> retrieveCategories();
 }


### PR DESCRIPTION
카테고리 전체 계층구조 변경

1. 계층 구조를 컴포지트 패턴을 이용하여 카테고리 탐색
2. 전체 조회 시 부모와 자식 관계로 API 제공
3. 계층마다 모두 HATEOAS 적용 완료
